### PR TITLE
feat: スマホでの操作性向上のためコントロールボタンサイズを拡大

### DIFF
--- a/textdrive-react/src/App.tsx
+++ b/textdrive-react/src/App.tsx
@@ -198,13 +198,15 @@ const ControlButtons = memo(({
     >
       <button
         onClick={onLeftPress}
-        className="bg-black text-white border-none w-15 h-15 rounded-full text-xl font-mono cursor-pointer flex items-center justify-center flex-shrink-0 hover:bg-gray-800 transition-colors active:scale-95"
+        className="bg-black text-white border-none w-20 h-20 sm:w-24 sm:h-24 rounded-full text-2xl sm:text-3xl font-mono cursor-pointer flex items-center justify-center flex-shrink-0 hover:bg-gray-800 transition-colors active:scale-95 touch-manipulation"
+        style={{ minWidth: '80px', minHeight: '80px' }}
       >
         ←
       </button>
       <button
         onClick={onRightPress}
-        className="bg-black text-white border-none w-15 h-15 rounded-full text-xl font-mono cursor-pointer flex items-center justify-center flex-shrink-0 hover:bg-gray-800 transition-colors active:scale-95"
+        className="bg-black text-white border-none w-20 h-20 sm:w-24 sm:h-24 rounded-full text-2xl sm:text-3xl font-mono cursor-pointer flex items-center justify-center flex-shrink-0 hover:bg-gray-800 transition-colors active:scale-95 touch-manipulation"
+        style={{ minWidth: '80px', minHeight: '80px' }}
       >
         →
       </button>


### PR DESCRIPTION
- ボタンサイズを60pxから80px（モバイル）/96px（デスクトップ）に拡大
- フォントサイズを24px（モバイル）/30px（デスクトップ）に調整
- touch-manipulationクラスを追加してタッチ操作を最適化
- レスポンシブデザインで画面サイズに応じてボタンサイズが調整される
- 最小サイズ80px×80pxを保証するインラインスタイルを追加