### PR TITLE
Convert training messages from Japanese to English

### DIFF
--- a/textdrive-rust/src/bin/train.rs
+++ b/textdrive-rust/src/bin/train.rs
@@ -10,7 +10,7 @@ fn main() {
     let mut agent = Agent::new();
     let mut stats = TrainingStats::new(RECENT_WINDOW_SIZE);
 
-    println!("=== Q学習スタート ===\n");
+    println!("=== Q-Learning Start ===\n");
 
     for episode in 1..=NUM_EPISODES {
         let final_distance = run_episode(&mut agent);
@@ -23,13 +23,13 @@ fn main() {
         }
     }
 
-    println!("\n=== 学習完了 ===");
-    println!("最高スコア: {}", agent.best_score);
+    println!("\n=== Training Complete ===");
+    println!("Best Score: {}", agent.best_score);
 
     agent
         .save("qtable.bin")
-        .expect("データの保存に失敗しました");
-    println!("データを保存しました");
+        .expect("Failed to save data");
+    println!("Data saved successfully");
 }
 
 fn run_episode(agent: &mut Agent) -> i32 {

--- a/textdrive-rust/src/bin/train.rs
+++ b/textdrive-rust/src/bin/train.rs
@@ -26,9 +26,7 @@ fn main() {
     println!("\n=== Training Complete ===");
     println!("Best Score: {}", agent.best_score);
 
-    agent
-        .save("qtable.bin")
-        .expect("Failed to save data");
+    agent.save("qtable.bin").expect("Failed to save data");
     println!("Data saved successfully");
 }
 


### PR DESCRIPTION
## Description

Convert training output messages from Japanese to English for better international accessibility and consistency with the codebase.

## Changes Made

- Updated Q-learning start message: `"=== Q学習スタート ===" → "=== Q-Learning Start ==="`
- Updated training completion message: `"=== 学習完了 ===" → "=== Training Complete ==="`
- Updated best score display: `"最高スコア:" → "Best Score:"`
- Updated error message: `"データの保存に失敗しました" → "Failed to save data"`
- Updated success message: `"データを保存しました" → "Data saved successfully"`

## Motivation

- Improves code readability for international contributors
- Maintains consistency with the rest of the codebase which uses English
- Makes the training output more accessible to a broader audience

## Testing

- [x] Code compiles without errors
- [x] Training messages display correctly in English
- [x] No functional changes to the training logic

## Type of Change

- [ ] Bug fix
- [x] Code improvement/refactoring
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
